### PR TITLE
fixed the URL for "APIs that suck"

### DIFF
--- a/apireadings.md
+++ b/apireadings.md
@@ -4,7 +4,7 @@
 * **(recommended)** [Aaron Swartz’s A Programmable Web](http://www.morganclaypool.com/doi/pdfplus/10.2200/S00481ED1V01Y201302WBE005): Chapter 3 -"Building for Search Engines: Following Rest"
 * **(required)** [Aaron Swartz’s A Programmable Web](http://www.morganclaypool.com/doi/pdfplus/10.2200/S00481ED1V01Y201302WBE005): Chapter 5 -"Building a Platform: Providing APIs"
 * [Aaron Swartz’s A Programmable Web](https://goo.gl/L21hJQ): Rest of the book is not required, but Chapter 7 is about Open Source if you're interested.
-* **(required)** APIs that suck [video] - [https://www.infoq.com/presentations/API-design-mistakes](https://www.infoq.com/presentations/
+* **(required)** APIs that suck [video] - [https://www.infoq.com/presentations/API-design-mistakes]
 
 Additioanl Resources
 * [REST API Design - Resource Modeling](https://www.thoughtworks.com/insights/blog/rest-api-design-resource-modeling) (Thoughtworks)


### PR DESCRIPTION
One of the links in the API reading was broken.
There was no space between the "]" and "(" so the URL didn't work. Now it works.
  